### PR TITLE
Enabled tracing & logging for Lambda API & API Gw

### DIFF
--- a/deployment/efs-file-manager.yaml
+++ b/deployment/efs-file-manager.yaml
@@ -113,7 +113,8 @@ Resources:
                   - "cloudformation:DeleteStack"
                   - "cloudformation:DescribeStacks"
                 Resource: "arn:aws:cloudformation:*:*:stack/*"
-
+      ManagedPolicyArns:
+        - "arn:aws:iam::aws:policy/AWSXRayDaemonWriteAccess"
   # File Manager API stack
   EFSFileManagerAPI:
     Type: "AWS::CloudFormation::Stack"

--- a/source/api/.chalice/config.json
+++ b/source/api/.chalice/config.json
@@ -9,7 +9,8 @@
     "dev": {
       "manage_iam_role": false,
       "iam_role_arn": "arn:aws:iam::999999999999:role/DummyRoleToBeReplaced",
-      "api_gateway_stage": "api"
+      "api_gateway_stage": "api",
+      "xray": true
     }
   }
 }

--- a/source/api/external_resources.json
+++ b/source/api/external_resources.json
@@ -34,6 +34,17 @@
         },
         "CodeUri": {"Bucket": {"Ref": "DeploymentPackageBucket"}, "Key": {"Ref": "DeploymentPackageKey"}}
       }
+    },
+    "RestAPI": {
+      "Properties": {
+        "AccessLogSetting": {
+          "DestinationArn": {
+            "Fn::Sub": "arn:aws:logs:eu-west-1:${AWS::AccountId}:log-group:/aws/apigateway/${stackPrefix}-EFSFileManagerAPI-AccessLogs:*"
+          },
+          "Format": "{\"requestId\":\"$context.requestId\", \"ip\": \"$context.identity.sourceIp\", \"caller\":\"$context.identity.caller\", \"user\":\"$context.identity.user\", \"requestTime\":\"$context.requestTime\", \"httpMethod\":\"$context.httpMethod\", \"resourcePath\":\"$context.resourcePath\", \"status\":\"$context.status\", \"protocol\":\"$context.protocol\" \"responseLength\":\"$context.responseLength\"}"
+        },
+        "TracingEnabled": true
     }
   }
+}
 }


### PR DESCRIPTION
*Issue #, if available:*
#86, #87 

*Description of changes:*
* Enabled tracing for API Lambda's via Chalice `config.json` file.
* Added `AWSXRayDaemonWriteAccess` managed policy to API Lambda's IAM Role as detailed [in this doc](https://docs.aws.amazon.com/lambda/latest/dg/services-xray.html#services-xray-permissions).
* Enabled tracing for API Gateway stage via Chalice `external_resources.json` file.
* Enabled access logging for API Gateway stage via Chalice `external_resources.json` file; used standard JSON format detailed [in this doc](https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-logging.html).

I confirm that I have tested the changes but would appreciate a review/

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
