### PR TITLE
version bump python to fix failed deployments

### DIFF
--- a/deployment/efs-file-manager-web.yaml
+++ b/deployment/efs-file-manager-web.yaml
@@ -291,7 +291,7 @@ Resources:
       Handler: website_helper.lambda_handler
       MemorySize: 256
       Role: !GetAtt WebsiteHelperRole.Arn
-      Runtime: python3.6
+      Runtime: python3.9
       Timeout: 900
       Environment:
         Variables:


### PR DESCRIPTION
*Issue #, if available:*

N/A

*Description of changes:*

Version bump python in lambda web deployment helper to prevent failed deployments due to python3.6 runtime EOL

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
