### PR TITLE
Enable versioning on logging bucket. Fix aws-amplify-vue dependency issue. Replace test AWS account ids with safe values.

### DIFF
--- a/deployment/efs-file-manager-web.yaml
+++ b/deployment/efs-file-manager-web.yaml
@@ -43,6 +43,8 @@ Resources:
             reason: "Logs bucket is private and does not require a bucket policy"
     Properties:
       AccessControl: LogDeliveryWrite
+      VersioningConfiguration: 
+        Status: Enabled
 
   EFSFileSimpleWebsiteBucket:
     Type: AWS::S3::Bucket

--- a/source/web/package.json
+++ b/source/web/package.json
@@ -11,7 +11,7 @@
     "@aws-amplify/api": "^3.2.29",
     "@aws-amplify/core": "^3.8.21",
     "aws-amplify": "^3.3.26",
-    "aws-amplify-vue": "^2.1.5",
+    "aws-amplify-vue": "2.1.5",
     "aws-sdk": "^2.858.0",
     "bootstrap": "^4.5.0",
     "bootstrap-vue": "^2.15.0",

--- a/test/unit/api/service_responses.py
+++ b/test/unit/api/service_responses.py
@@ -82,7 +82,7 @@ efs_describe_file_systems_no_marker_response = {
             'LifeCycleState': 'available',
             'Name': 'MyFileSystem',
             'NumberOfMountTargets': 1,
-            'OwnerId': '012345678912',
+            'OwnerId': '123456789012',
             'PerformanceMode': 'generalPurpose',
             'SizeInBytes': {
                 'Value': 6144,
@@ -110,7 +110,7 @@ efs_describe_file_systems_marker_response = {
             'LifeCycleState': 'available',
             'Name': 'MyFileSystem',
             'NumberOfMountTargets': 1,
-            'OwnerId': '012345678912',
+            'OwnerId': '123456789012',
             'PerformanceMode': 'generalPurpose',
             'SizeInBytes': {
                 'Value': 6144,
@@ -136,7 +136,7 @@ efs_describe_mount_targets_response = {
             'LifeCycleState': 'available',
             'MountTargetId': 'fsmt-12340abc',
             'NetworkInterfaceId': 'eni-cedf6789',
-            'OwnerId': '012345678912',
+            'OwnerId': '123456789012',
             'SubnetId': 'subnet-1234abcd',
         },
     ],


### PR DESCRIPTION
*Issue #, if available: #188

*Description of changes:
 - Enables versioning on Logging bucket to prevent automated bugs being created
 - Fixes the use of a broken dependency version (aws-amplify-vue) - This appears to be causing the lack of login screen when deploying from Github (#188)
 - Replaces test AWS account IDs with safe values.

Let me know if it makes more sense to keep tickets separate and have these each as their own PR.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
