### PR TITLE
Fix file manager lambda could not be created

### DIFF
--- a/deployment/simple-file-manager-for-amazon-efs.yaml
+++ b/deployment/simple-file-manager-for-amazon-efs.yaml
@@ -175,6 +175,7 @@ Resources:
                   - "elasticfilesystem:CreateAccessPoint"
                   - "elasticfilesystem:DescribeAccessPoints"
                   - "elasticfilesystem:DescribeMountTargetSecurityGroups"
+                  - "elasticfilesystem:TagResource"
                 Resource:
                   - "arn:aws:elasticfilesystem:*:*:file-system/*"
                   - "arn:aws:elasticfilesystem:*:*:access-point/*"


### PR DESCRIPTION
*Issue #, if available: -


*Description of changes:*
File manager lambda failed to create in my AWS account.
I have attached an image, please refer to it for errors.

To resolve this error, I have added 'elasticfilesystem:TagResource' to the "API handler Lambda function" that is creating CloudFormation.
Thanks.

![image](https://github.com/aws-solutions/simple-file-manager-for-amazon-efs/assets/58356459/de4891e8-7bed-4ea0-a42c-41ddc02220e3)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

