### PR TITLE
update to v1.5.3 open-source release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.3] - 2023-09-20
+### Bug Fixes:
+- Merge Website Bucket policy statements to prevent deployment failures on policy creation slowdowns
+- Remove uneeded exit in Unit test script
+- Added downline dependencies to NOTICE.txt
+
+### Security:
+- Upgrade Node version to 18
+- Upgrade Python runtime to 3.11
+- Update NPM packages to fix vulnerabilities
+
 ## [1.5.2] - 2023-05-19
 ### Bug Fixes:
 - elasticfilesystem:TagResource permission added to Manager Lambda

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -13,19 +13,50 @@ THIRD PARTY COMPONENTS
 This software includes third party software subject to the following copyrights:
 
 AWS SDK under the Apache License Version 2.0
-Pytest under the MIT License (MIT)
-Selenium under the Apache License Version 2.0
-Boto3 under the Apache License Version 2.0
 Pyyaml under the MIT License (MIT)
-Requests_toolbelt under the Apache License Version 2.0
 Urllib3 under the the MIT License (MIT)
-Aws-amplify under the Apache License Version 2.0
-Aws-amplify-vue under the Apache License Version 2.0
-Bootstrap under the MIT License (MIT)
-Bootstrap-vue under the MIT License (MIT)
-Core-js under the MIT License (MIT)
 Vue under the MIT License (MIT)
 vue-router under the MIT License (MIT)
 vue-stepper-component under the MIT License (MIT)
 vue2-dropzone under the MIT License (MIT)
 webpack under the MIT License (MIT)
+PySocks under the BSD-3-Clause License
+attrs under the MIT License (MIT)
+blessed under the MIT License (MIT)
+boolean.py under the BSD-2-Clause license
+boto3 under the Apache License Version 2.0
+botocore under the Apache License Version 2.0
+chalice under the Apache License Version 2.0
+click under the BSD-3-Clause license
+coverage under the Apache License Version 2.0
+exceptiongroup under the MIT License (MIT)
+h11 under the MIT License (MIT)
+iniconfig under the MIT License (MIT)
+inquirer under the MIT License (MIT)
+jmespath under the MIT License (MIT)
+license-expression under the Apache License Version 2.0
+outcome under the Apache License Version 2.0
+pluggy under the MIT License (MIT)
+pytest under the MIT License (MIT)
+pytest-cov under the MIT License (MIT)
+pytest-mock under the MIT License (MIT)
+python-dateutil under the Apache Software License
+python-editor under the Apache Software License
+readchar under the MIT License (MIT)
+requests-toolbelt under the Apache License Version 2.0
+s3transfer under the Apache License Version 2.0
+selenium under the Apache License Version 2.0
+sniffio under the Apache License Version 2.0
+tomli under the MIT License (MIT)
+trio under the Apache License Version 2.0
+trio-websocket under the MIT License (MIT)
+typing_extensions under the Python Software Foundation License
+wsproto under the MIT License (MIT)
+@aws-amplify/api under the Apache License Version 2.0
+@aws-amplify/core under the Apache License Version 2.0
+aws-amplify under the Apache License Version 2.0
+aws-amplify-vue under the Apache License Version 2.0
+aws-sdk under the Apache License Version 2.0
+bootstrap under the MIT License (MIT)
+bootstrap-vue under the MIT License (MIT)
+core-js under the MIT License (MIT)

--- a/deployment/build-s3-dist.sh
+++ b/deployment/build-s3-dist.sh
@@ -274,6 +274,7 @@ chalice --debug package --merge-template external_resources.json dist
 echo "...chalice done"
 echo "cp ./dist/sam.json $global_dist_dir/file-manager-api-stack.template"
 cp dist/sam.json "$global_dist_dir"/file-manager-api-stack.template
+sed -i.orig -e "$new_version" "$global_dist_dir/file-manager-api-stack.template"
 if [ $? -ne 0 ]; then
   echo "ERROR: Failed to build api template"
   exit 1

--- a/deployment/efs-file-manager-auth.yaml
+++ b/deployment/efs-file-manager-auth.yaml
@@ -11,7 +11,7 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 AWSTemplateFormatVersion: "2010-09-09"
-Description: (SO0145) Simple File Manager for Amazon EFS Solution Auth %%VERSION%% 
+Description: (SO0145) Simple File Manager for Amazon EFS Solution Auth %%VERSION%%
 
 Parameters:
   AdminEmail:
@@ -90,7 +90,7 @@ Resources:
           - - index
             - .handler
         Role: !GetAtt CognitoRoleMapperLambdaExecutionRole.Arn
-        Runtime: python3.9
+        Runtime: python3.11
         Timeout: 30
 
   CognitoRoleMapperLambdaExecutionRole:

--- a/deployment/efs-file-manager-web.yaml
+++ b/deployment/efs-file-manager-web.yaml
@@ -11,7 +11,7 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 AWSTemplateFormatVersion: "2010-09-09"
-Description: (SO0145) Simple File Manager for Amazon EFS Solution Web %%VERSION%% 
+Description: (SO0145) Simple File Manager for Amazon EFS Solution Web %%VERSION%%
 
 Parameters:
   FileManagerAPIEndpoint:
@@ -34,6 +34,7 @@ Mappings:
 Resources:
   EFSFileSimpleLoggingBucket:
     Type: 'AWS::S3::Bucket'
+    DeletionPolicy: Retain
     Metadata:
       cfn_nag:
         rules_to_suppress:
@@ -82,20 +83,6 @@ Resources:
             AbortIncompleteMultipartUpload:
               DaysAfterInitiation: 1
 
-  WebBucketPolicy:
-    Type: AWS::S3::BucketPolicy
-    Properties:
-      Bucket: !Ref EFSFileSimpleWebsiteBucket
-      PolicyDocument:
-        Statement:
-          - Effect: Deny
-            Principal: "*"
-            Action: "*"
-            Resource: !Sub "arn:aws:s3:::${EFSFileSimpleWebsiteBucket}/*"
-            Condition:
-              Bool:
-                aws:SecureTransport: false
-
   CopyWebSource:
     Type: Custom::WebsiteDeployHelper
     Properties:
@@ -130,6 +117,13 @@ Resources:
               - !Sub "arn:aws:s3:::${EFSFileSimpleWebsiteBucket}/*"
             Principal:
               CanonicalUser: !GetAtt EFSFileSimpleOriginAccessIdentity.S3CanonicalUserId
+          - Effect: Deny
+            Principal: "*"
+            Action: "*"
+            Resource: !Sub "arn:aws:s3:::${EFSFileSimpleWebsiteBucket}/*"
+            Condition:
+              Bool:
+                aws:SecureTransport: false
 
   EFSFileSimpleWebsiteDistribution:
     Type: AWS::CloudFront::Distribution
@@ -252,7 +246,7 @@ Resources:
       Handler: website_helper.lambda_handler
       MemorySize: 256
       Role: !GetAtt WebsiteHelperRole.Arn
-      Runtime: python3.9
+      Runtime: python3.11
       Timeout: 900
       Environment:
         Variables:

--- a/deployment/simple-file-manager-for-amazon-efs.yaml
+++ b/deployment/simple-file-manager-for-amazon-efs.yaml
@@ -16,7 +16,7 @@
 # author: aws-solutions-builder@
 AWSTemplateFormatVersion: 2010-09-09
 
-Description: (SO0145) Simple File Manager for Amazon EFS Solution Main %%VERSION%% 
+Description: (SO0145) Simple File Manager for Amazon EFS Solution Main %%VERSION%%
 
 Parameters:
   AdminEmail:

--- a/source/api/chalicelib/file-manager-ap-lambda.template
+++ b/source/api/chalicelib/file-manager-ap-lambda.template
@@ -248,7 +248,7 @@ Resources:
       MemorySize: 512
       PackageType: "Zip"
       Role: !GetAtt ManagedAccessPointFunctionRole.Arn
-      Runtime: "python3.9"
+      Runtime: "python3.11"
       Timeout: 60
       VpcConfig:
         SecurityGroupIds:

--- a/source/api/external_resources.json
+++ b/source/api/external_resources.json
@@ -1,4 +1,5 @@
 {
+  "Description": "(SO0145) Simple File Manager for Amazon EFS Solution Auth %%VERSION%%",
   "Parameters": {
     "DeploymentPackageBucket": {
       "Type": "String",

--- a/source/web/package-lock.json
+++ b/source/web/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "web",
       "version": "0.1.0",
+      "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/api": "^4.0.63",
         "@aws-amplify/core": "^4.7.15",
@@ -7791,9 +7792,9 @@
       }
     },
     "node_modules/@babel/register/node_modules/semver": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
       "peer": true,
       "bin": {
         "semver": "bin/semver"
@@ -10022,9 +10023,9 @@
       }
     },
     "node_modules/@vue/babel-preset-app/node_modules/semver": {
-      "version": "7.3.8",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
       "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
@@ -10518,9 +10519,9 @@
       }
     },
     "node_modules/@vue/cli-shared-utils/node_modules/semver": {
-      "version": "7.3.8",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
       "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
@@ -12743,9 +12744,9 @@
       }
     },
     "node_modules/css-loader/node_modules/semver": {
-      "version": "7.3.8",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
       "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
@@ -13963,9 +13964,9 @@
       }
     },
     "node_modules/eslint/node_modules/semver": {
-      "version": "7.3.8",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
       "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
@@ -14182,9 +14183,9 @@
       }
     },
     "node_modules/execa/node_modules/semver": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
       "bin": {
         "semver": "bin/semver"
       }
@@ -14602,9 +14603,9 @@
       "dev": true
     },
     "node_modules/fast-xml-parser": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.2.4.tgz",
-      "integrity": "sha512-fbfMDvgBNIdDJLdLOwacjFAPYt67tr31H9ZhWSm45CDAxvd0I6WTlSOUo7K2P/K5sA5JgMKG64PI3DMcaFdWpQ==",
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.2.5.tgz",
+      "integrity": "sha512-B9/wizE4WngqQftFPmdaMYlXoJlJOYxGQOanC77fq9k8+Z0v5dDSVh+3glErdIROP//s/jgb7ZuxKfB8nVyo0g==",
       "funding": [
         {
           "type": "paypal",
@@ -19071,9 +19072,9 @@
       }
     },
     "node_modules/normalize-package-data/node_modules/semver": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
       "dev": true,
       "bin": {
         "semver": "bin/semver"
@@ -19968,9 +19969,9 @@
       }
     },
     "node_modules/postcss-loader/node_modules/semver": {
-      "version": "7.3.8",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
       "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
@@ -21382,9 +21383,9 @@
       }
     },
     "node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "bin": {
         "semver": "bin/semver.js"
       }
@@ -24135,9 +24136,9 @@
       "dev": true
     },
     "node_modules/word-wrap": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
-      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"

--- a/source/web/package.json
+++ b/source/web/package.json
@@ -1,6 +1,8 @@
 {
   "name": "web",
   "version": "0.1.0",
+  "license": "Apache-2.0",
+  "description": "Simple File Manager for Amazon EFS Frontend",
   "private": true,
   "scripts": {
     "serve": "vue-cli-service serve",
@@ -52,9 +54,9 @@
     "not dead"
   ],
   "overrides": {
-    "fast-xml-parser": "4.2.4"
+    "fast-xml-parser": "4.2.5"
   },
   "resolutions": {
-    "fast-xml-parser": "4.2.4"
+    "fast-xml-parser": "4.2.5"
  } 
 }

--- a/test/unit/run_unit.sh
+++ b/test/unit/run_unit.sh
@@ -50,27 +50,12 @@ if [ "$1" = "" ]; then
 elif [ "$1" = "api" ]; then
     echo "Running api unit tests"
     pytest api/ -s -W ignore::DeprecationWarning -W ignore::UserWarning -p no:cacheprovider --cov=../../source/api/ --cov-report xml --cov-append api
-    if [ $? -eq 0 ]; then
-	    exit 0
-    else
-	    exit 1
-    fi
 elif [ "$1" = "manager" ]; then
     echo "Running file manager lambda unit tests"
     pytest manager/ -s -W ignore::DeprecationWarning -p no:cacheprovider --cov=../../source/api/chalicelib/ --cov-report xml --cov-append manager
-    if [ $? -eq 0 ]; then
-	    exit 0
-    else
-	    exit 1
-    fi
 elif [ "$1" = "all" ]; then
     echo "Running all unit tests"
     pytest ./ -s -W ignore::DeprecationWarning -W ignore::UserWarning -p no:cacheprovider --cov=../../ --cov-report xml
-    if [ $? -eq 0 ]; then
-	    exit 0
-    else
-	    exit 1
-    fi
 else
     echo "Invalid positional parameter. Quitting."
     exit 1


### PR DESCRIPTION
- Updates Github to v1.5.3 open source release
### Bug Fixes:
- Merge Website Bucket policy statements to prevent deployment failures on policy creation slowdowns
- Remove uneeded exit in Unit test script
- Added downline dependencies to NOTICE.txt

### Security:
- Upgrade Node version to 18
- Upgrade Python runtime to 3.11
- Update NPM packages to fix vulnerabilities

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
