### PR TITLE
Update to v1.5.7 open-source release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
+## [1.5.7] - 2024-05-30
+### Fixed:
+- Updated API Handler Python runtime to 3.11 due to Python 3.8 Lambda runtime deprecation
+
+### Changes:
+- Updated spoke template descriptions to include suffix
+
 ## [1.5.6] - 2024-04-09
-### Fixed
+### Fixed:
 - Updated axios sub-dependency to use v0.28.0 to resolve security vulnerabilities:
   - [CVE-2023-45857]
   - [CVE-2024-28849]

--- a/deployment/efs-file-manager-auth.yaml
+++ b/deployment/efs-file-manager-auth.yaml
@@ -11,7 +11,7 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 AWSTemplateFormatVersion: "2010-09-09"
-Description: (SO0145) Simple File Manager for Amazon EFS Solution Auth %%VERSION%%
+Description: (SO0145-Auth) Simple File Manager for Amazon EFS Solution Auth %%VERSION%%
 
 Parameters:
   AdminEmail:

--- a/deployment/efs-file-manager-web.yaml
+++ b/deployment/efs-file-manager-web.yaml
@@ -11,7 +11,7 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 AWSTemplateFormatVersion: "2010-09-09"
-Description: (SO0145) Simple File Manager for Amazon EFS Solution Web %%VERSION%%
+Description: (SO0145-Web) Simple File Manager for Amazon EFS Solution Web %%VERSION%%
 
 Parameters:
   FileManagerAPIEndpoint:

--- a/source/api/external_resources.json
+++ b/source/api/external_resources.json
@@ -1,5 +1,5 @@
 {
-  "Description": "(SO0145) Simple File Manager for Amazon EFS Solution Auth %%VERSION%%",
+  "Description": "(SO0145-Auth) Simple File Manager for Amazon EFS Solution Auth %%VERSION%%",
   "Parameters": {
     "DeploymentPackageBucket": {
       "Type": "String",
@@ -43,7 +43,7 @@
             }
         },
       "Properties": {
-        "Runtime": "python3.8",
+        "Runtime": "python3.11",
         "Role": {"Ref": "ApiHandlerIamRole"},
         "Environment": {
           "Variables": {


### PR DESCRIPTION
- Updates Github to v1.5.7 open source release
### Fixed:
- Updated API Handler Python runtime to 3.11 due to Python 3.8 Lambda runtime deprecation

### Changes:
- Updated spoke template descriptions to include suffix

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
