### PR TITLE
Update to v1.5.13 open-source release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.13] - 2025-02-06
+### Security: 
+- Bump nanoid to `3.3.8` to resolve CVE [CVE-2024-55565](https://github.com/advisories/GHSA-mwcw-c2x4-8c55)
+- Bump path-to-regexp to`0.1.12` to resolve CVE [CVE-2024-52798](https://github.com/advisories/GHSA-rhx6-c78j-4q9w)
+- Override vue dependencies to `3.4.34` to resolve CVE [CVE-2024-9506](https://github.com/advisories/GHSA-5j4c-8p2g-v4jx)
+
 ## [1.5.12] - 2024-11-19
 ### Security:
 - Bump cross-spawn to `7.0.6` to resolve [CVE-2024-9506](https://github.com/advisories/GHSA-5j4c-8p2g-v4jx)
@@ -13,8 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.5.11] - 2024-10-29
 ### Security: 
-- Bump http-proxy-middleware to `2.0.7` to resolve [cve-2024-21536](https://github.com/advisories/GHSA-c7qv-q95q-8v27)
-- Bump cookie to `0.7.0` to resolve CVE [ CVE-2024-47764](https://github.com/advisories/GHSA-pxg6-pf52-xh8x)  
+- Bump http-proxy-middleware to `2.0.7` to resolve [CVE-2024-21536](https://github.com/advisories/GHSA-c7qv-q95q-8v27)
+- Bump cookie to `0.7.0` to resolve CVE [CVE-2024-47764](https://github.com/advisories/GHSA-pxg6-pf52-xh8x)  
 
 ## [1.5.10] - 2024-09-20
 ### Security: 

--- a/source/web/package-lock.json
+++ b/source/web/package-lock.json
@@ -13248,39 +13248,6 @@
         "vue2-filters": "^0.7.2"
       }
     },
-    "node_modules/aws-amplify-vue/node_modules/@vue/compiler-sfc": {
-      "version": "2.7.16",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-2.7.16.tgz",
-      "integrity": "sha512-KWhJ9k5nXuNtygPU7+t1rX6baZeqOYLEforUPjgNDBnLicfHCoi48H87Q8XyLZOrNNsmhuwKqtpDQWjEFe6Ekg==",
-      "dependencies": {
-        "@babel/parser": "^7.23.5",
-        "postcss": "^8.4.14",
-        "source-map": "^0.6.1"
-      },
-      "optionalDependencies": {
-        "prettier": "^1.18.2 || ^2.0.0"
-      }
-    },
-    "node_modules/aws-amplify-vue/node_modules/qrcode.vue": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/qrcode.vue/-/qrcode.vue-1.7.0.tgz",
-      "integrity": "sha512-R7t6Y3fDDtcU7L4rtqwGUDP9xD64gJhIwpfjhRCTKmBoYF6SS49PIJHRJ048cse6OI7iwTwgyy2C46N9Ygoc6g==",
-      "license": "MIT",
-      "peerDependencies": {
-        "vue": "^2.0.0"
-      }
-    },
-    "node_modules/aws-amplify-vue/node_modules/vue": {
-      "version": "2.7.16",
-      "resolved": "https://registry.npmjs.org/vue/-/vue-2.7.16.tgz",
-      "integrity": "sha512-4gCtFXaAA3zYZdTp5s4Hl2sozuySsgz4jy1EnpBHNfpMa9dK1ZCG7viqBPCwXtmgc8nHqUsAu3G4gtmXkkY3Sw==",
-      "deprecated": "Vue 2 has reached EOL and is no longer actively maintained. See https://v2.vuejs.org/eol/ for more details.",
-      "license": "MIT",
-      "dependencies": {
-        "@vue/compiler-sfc": "2.7.16",
-        "csstype": "^3.1.0"
-      }
-    },
     "node_modules/aws-sdk": {
       "version": "2.1664.0",
       "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1664.0.tgz",
@@ -16256,9 +16223,9 @@
       }
     },
     "node_modules/express": {
-      "version": "4.21.1",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.21.1.tgz",
-      "integrity": "sha512-YSFlK1Ee0/GC8QaO91tHcDxJiE/X4FbpAyQWkxAvG6AXCuR65YzK8ua6D9hvi/TzUfZMpc+BwuM1IPw8fmQBiQ==",
+      "version": "4.21.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.21.2.tgz",
+      "integrity": "sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -16281,7 +16248,7 @@
         "methods": "~1.1.2",
         "on-finished": "2.4.1",
         "parseurl": "~1.3.3",
-        "path-to-regexp": "0.1.10",
+        "path-to-regexp": "0.1.12",
         "proxy-addr": "~2.0.7",
         "qs": "6.13.0",
         "range-parser": "~1.2.1",
@@ -16296,16 +16263,10 @@
       },
       "engines": {
         "node": ">= 0.10.0"
-      }
-    },
-    "node_modules/express/node_modules/cookie": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.1.tgz",
-      "integrity": "sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/express/node_modules/debug": {
@@ -20487,9 +20448,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.7",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
-      "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
+      "version": "3.3.8",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.8.tgz",
+      "integrity": "sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w==",
       "funding": [
         {
           "type": "github",
@@ -21211,10 +21172,11 @@
       "license": "MIT"
     },
     "node_modules/path-to-regexp": {
-      "version": "0.1.10",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.10.tgz",
-      "integrity": "sha512-7lf7qcQidTku0Gu3YDPc8DJ1q7OOucfa/BSsIwjuh56VU7katFvuM8hULfkwB3Fns/rsVF7PwPKVw1sl5KQS9w==",
-      "dev": true
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
+      "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/path-type": {
       "version": "4.0.0",
@@ -21905,6 +21867,7 @@
       "version": "2.8.8",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
       "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "bin": {
@@ -22162,6 +22125,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/qrcode.vue": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/qrcode.vue/-/qrcode.vue-1.7.0.tgz",
+      "integrity": "sha512-R7t6Y3fDDtcU7L4rtqwGUDP9xD64gJhIwpfjhRCTKmBoYF6SS49PIJHRJ048cse6OI7iwTwgyy2C46N9Ygoc6g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "vue": "^2.0.0"
       }
     },
     "node_modules/qs": {

--- a/source/web/package.json
+++ b/source/web/package.json
@@ -57,13 +57,15 @@
     "postcss": "8.4.31",
     "axios": "0.28.0",
     "cookie": "0.7.0",
-    "cross-spawn": "^7.0.6"
+    "cross-spawn": "^7.0.6",
+    "vue": "^3.4.34"
   },
   "resolutions": {
     "fast-xml-parser": "4.4.1",
     "postcss": "8.4.31",
     "axios": "0.28.0",
     "cookie": "0.7.0",
-    "cross-spawn": "^7.0.6"
+    "cross-spawn": "^7.0.6",
+    "vue": "^3.4.34"
   }
 }


### PR DESCRIPTION
Updates Github to v1.5.13 open source release

## [1.5.13] - 2025-02-06
### Security: 
- Bump nanoid to `3.3.8` to resolve CVE [CVE-2024-55565](https://github.com/advisories/GHSA-mwcw-c2x4-8c55)
- Bump path-to-regexp to`0.1.12` to resolve CVE [CVE-2024-52798](https://github.com/advisories/GHSA-rhx6-c78j-4q9w)
- Override vue dependencies to `3.4.34` to resolve CVE [CVE-2024-9506](https://github.com/advisories/GHSA-5j4c-8p2g-v4jx)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.