### PR TITLE
Update to v1.5.14 open-source release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.14] - 2025-03-14
+### Security: 
+- Upgrade axios to `1.8.2` to resolve CVE [CVE-2025-27152](https://avd.aquasec.com/nvd/2025/cve-2025-27152/)
+
 ## [1.5.13] - 2025-02-06
 ### Security: 
 - Bump nanoid to `3.3.8` to resolve CVE [CVE-2024-55565](https://github.com/advisories/GHSA-mwcw-c2x4-8c55)

--- a/source/web/package-lock.json
+++ b/source/web/package-lock.json
@@ -13305,12 +13305,12 @@
       }
     },
     "node_modules/axios": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.28.0.tgz",
-      "integrity": "sha512-Tu7NYoGY4Yoc7I+Npf9HhUMtEEpV7ZiLH9yndTCoNhcpBH0kwcvFbzYN9/u5QKI5A6uefjsNNWaz5olJVYS62Q==",
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.8.2.tgz",
+      "integrity": "sha512-ls4GYBm5aig9vWx8AWDSGLpnpDQRtWAfrjU+EuytuODrFBkqesN2RkOQCBzrA1RQNHw1SmRMSDDDSwzNAYQ6Rg==",
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.0",
+        "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",
         "proxy-from-env": "^1.1.0"
       }

--- a/source/web/package.json
+++ b/source/web/package.json
@@ -55,7 +55,7 @@
   "overrides": {
     "fast-xml-parser": "4.4.1",
     "postcss": "8.4.31",
-    "axios": "0.28.0",
+    "axios": "1.8.2",
     "cookie": "0.7.0",
     "cross-spawn": "^7.0.6",
     "vue": "^3.4.34"
@@ -63,7 +63,7 @@
   "resolutions": {
     "fast-xml-parser": "4.4.1",
     "postcss": "8.4.31",
-    "axios": "0.28.0",
+    "axios": "1.8.2",
     "cookie": "0.7.0",
     "cross-spawn": "^7.0.6",
     "vue": "^3.4.34"


### PR DESCRIPTION
Updates Github to v1.5.14 open source release

## [1.5.14] - 2025-03-14
### Security: 
- Upgrade axios to `1.8.2` to resolve CVE [CVE-2025-27152](https://avd.aquasec.com/nvd/2025/cve-2025-27152/)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.